### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0](https://github.com/Grazulex/shipmark/releases/tag/v2.0.0) (2026-01-08)
+
+### ⚠ BREAKING CHANGES
+
+- add multi-file version support for Python and YAML ([683e2a1](https://github.com/Grazulex/shipmark/commit/683e2a1a046b8f1d5777a5eb2c3d578cf0db90c1))
+  - version.files now accepts objects with path/key/prefix
+
+### Features
+
+- add multi-file version support for Python and YAML ([683e2a1](https://github.com/Grazulex/shipmark/commit/683e2a1a046b8f1d5777a5eb2c3d578cf0db90c1))
+  - version.files now accepts objects with path/key/prefix
+
+### Chores
+
+- add .claude/ to gitignore ([ee618c3](https://github.com/Grazulex/shipmark/commit/ee618c3c0c37b22d71c49ab9e91eddea6f2f7e89))
+- **release:** 1.0.0 ([b4ede1e](https://github.com/Grazulex/shipmark/commit/b4ede1ef9f175bd0cdc6ca73f68b245dbb8579e3))
 ## [1.0.0](https://github.com/Grazulex/shipmark/releases/tag/v1.0.0) (2025-12-25)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,50 +1,63 @@
 {
-	"name": "@grazulex/shipmark",
-	"version": "1.0.0",
-	"description": "A beautiful CLI for managing Git releases, changelogs, and versioning",
-	"type": "module",
-	"main": "dist/cli.js",
-	"bin": {
-		"shipmark": "./dist/cli.js"
-	},
-	"files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
-	"scripts": {
-		"dev": "tsx src/cli.ts",
-		"build": "tsc && node scripts/fix-imports.mjs",
-		"check": "biome check .",
-		"format": "biome format --write .",
-		"lint": "biome lint .",
-		"test": "vitest",
-		"test:run": "vitest run",
-		"prepublishOnly": "npm run check && npm run build",
-		"install:global": "npm run build && npm link",
-		"uninstall:global": "npm unlink -g @grazulex/shipmark"
-	},
-	"keywords": ["git", "release", "changelog", "version", "semver", "cli", "tag"],
-	"author": "Grazulex",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/grazulex/shipmark.git"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"dependencies": {
-		"boxen": "^8.0.1",
-		"chalk": "^5.3.0",
-		"cli-table3": "^0.6.5",
-		"commander": "^12.1.0",
-		"inquirer": "^12.2.0",
-		"ora": "^8.1.1",
-		"smol-toml": "^1.6.0",
-		"yaml": "^2.8.2"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
-		"@types/node": "^22.10.1",
-		"tsx": "^4.19.2",
-		"typescript": "^5.7.2",
-		"vitest": "^4.0.7"
-	}
+  "name": "@grazulex/shipmark",
+  "version": "2.0.0",
+  "description": "A beautiful CLI for managing Git releases, changelogs, and versioning",
+  "type": "module",
+  "main": "dist/cli.js",
+  "bin": {
+    "shipmark": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "dev": "tsx src/cli.ts",
+    "build": "tsc && node scripts/fix-imports.mjs",
+    "check": "biome check .",
+    "format": "biome format --write .",
+    "lint": "biome lint .",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "prepublishOnly": "npm run check && npm run build",
+    "install:global": "npm run build && npm link",
+    "uninstall:global": "npm unlink -g @grazulex/shipmark"
+  },
+  "keywords": [
+    "git",
+    "release",
+    "changelog",
+    "version",
+    "semver",
+    "cli",
+    "tag"
+  ],
+  "author": "Grazulex",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grazulex/shipmark.git"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "boxen": "^8.0.1",
+    "chalk": "^5.3.0",
+    "cli-table3": "^0.6.5",
+    "commander": "^12.1.0",
+    "inquirer": "^12.2.0",
+    "ora": "^8.1.1",
+    "smol-toml": "^1.6.0",
+    "yaml": "^2.8.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.7"
+  }
 }


### PR DESCRIPTION
## Release v2.0.0

### Breaking Changes
- Configuration `version.files` now accepts `VersionFileEntry[]` (string or object with path/key/prefix)

### Features
- **pyproject.toml support**: Python projects with PEP 621, Poetry, or Setuptools
- **YAML support**: Helm values.yaml, K8s manifests with configurable key path (dot notation)
- **syncCheck option**: Validate version consistency across files before release
- **Handler architecture**: Modular, extensible file format handlers

### Changes
- Updated CHANGELOG.md
- Bumped version to 2.0.0

---
After merge, the v2.0.0 tag will be pushed and npm package published.